### PR TITLE
No more clutter if output is redirected to  file

### DIFF
--- a/bkup_rpimage.sh
+++ b/bkup_rpimage.sh
@@ -374,7 +374,7 @@ else
 fi
 
 # Trap keyboard interrupt (ctrl-c)
-trap ctrl_c SIGINT
+trap ctrl_c SIGINT SIGTERM
 
 # Check for dependencies
 for c in dd losetup parted sfdisk partx mkfs.vfat mkfs.ext4 mountpoint rsync; do

--- a/bkup_rpimage.sh
+++ b/bkup_rpimage.sh
@@ -19,7 +19,7 @@
 # 		      Thus output to file is no more cluttered.
 #
 # 2019-03-18 Dolorosus: 
-#               add: exclusion of files below /tmp,/proc,/run,/sys and 
+#               add: exclusion of files below /tmp,/proc,/run,/sys./mnt and 
 #                    also the swapfile /var/swap will be excluded from backup.
 #               add: Bumping the version to 1.1
 #
@@ -51,7 +51,7 @@ setup () {
                 RESET=$(tput setaf 9)
                 BOLD=$(tput bold)
                 NOATT=$(tput sgr0)
-				}||{
+	}||{
                 RED=""
                 GREEN=""
                 YELLOW=""
@@ -62,7 +62,7 @@ setup () {
                 RESET=""
                 BOLD=""
                 NOATT=""
-				}
+	}
         MYNAME=$(basename $0)
 }
 
@@ -150,10 +150,10 @@ do_backup () {
         trace "Starting rsync backup of / and /boot/ to $MOUNTDIR"
         if [ -n "$opt_log" ]; then
             rsync -aEvx --del --stats --log-file $LOG  /boot/ $MOUNTDIR/boot/
-            rsync -aEvx --del --stats --log-file $LOG --exclude={'tmp/**','proc/**','run/**','sys/**','var/swap'} / $MOUNTDIR/
+            rsync -aEvx --del --stats --log-file $LOG --exclude={'tmp/**','proc/**','run/**','sys/**','mnt/**','var/swap'} / $MOUNTDIR/
         else
             rsync -aEvx --del --stats /boot/ $MOUNTDIR/boot/
-            rsync -aEvx --del --stats --exclude={'tmp/**','proc/**','run/**','sys/**','var/swap'} / $MOUNTDIR/
+            rsync -aEvx --del --stats --exclude={'tmp/**','proc/**','run/**','sys/**','mnt/**','var/swap'} / $MOUNTDIR/
         fi
     else
         trace "Skipping rsync since $MOUNTDIR is not a mount point"


### PR DESCRIPTION
 fixed: Define colors only if connected to a terminal.
         Thus output to file is no more cluttered.